### PR TITLE
Remove unnecessary background page for Chrome/Opera extension

### DIFF
--- a/operablink/index.html
+++ b/operablink/index.html
@@ -1,7 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-  </head>
-  <body>
-  </body>
-</html>

--- a/operablink/manifest.json
+++ b/operablink/manifest.json
@@ -4,7 +4,6 @@
 "description" : "Adds a button that lets you download YouTube videos as MP4 and FLV.",
 "manifest_version" : 2,
 "version" : "1.8.5.1",
-"background" : {"page" : "index.html"},
 "icons" : {"128": "icons/icon.png"},
 "content_scripts": [
 {"js": ["includes/yt.user.js"], "matches": ["http://www.youtube.com/*", "https://www.youtube.com/*"], "exclude_matches": ["http://www.youtube.com/embed/*", "https://www.youtube.com/embed/*"], "run_at": "document_start"}],


### PR DESCRIPTION
Background page is empty and does nothing anyway, so let's remove it for performance.